### PR TITLE
ch04 preprocessing: add Check for not supported value and error handlers

### DIFF
--- a/docs/ch04-zabbix-collecting-data/preprocessing.md
+++ b/docs/ch04-zabbix-collecting-data/preprocessing.md
@@ -458,6 +458,76 @@ for data integrity or crafting your trigger expressions later on.
 
 ---
 
+### Check for not supported value and error handlers
+
+So far every preprocessing step we looked at transforms a value that was
+collected successfully. But what happens when an item *fails* to collect a
+value at all? An SNMP OID returns an error, a file cannot be read, an agent
+key is unsupported on that host. In that case the item becomes **not
+supported**, and by default Zabbix skips the rest of the preprocessing
+pipeline.
+
+This matters more than it first looks. Every time an item flips to *not
+supported* (and every time a trigger can no longer be calculated and goes to
+*unknown*), Zabbix writes an **internal event** to the database. On a single
+host this is harmless. But across a large environment, these internal events
+can be generated continuously, on every poll, for every broken item: a
+low-level discovery that picks up virtual or transient entities, an SNMP
+template polling hardware that is not present, a file that only exists on some
+hosts. They pile up in the `events` and `event_tag` tables, give the
+housekeeper far more to delete, and bury the genuinely interesting problems in
+noise.
+
+Zabbix gives us two tools to deal with this in preprocessing.
+
+**Check for not supported value** is a special step that, unlike the others,
+runs *because* the item failed to collect. Placed as the first step, it lets
+us catch the collection error and decide what to do with it, instead of
+letting the item drop straight to *not supported*.
+
+**Error handlers** (the *Custom on fail* option) can be attached to almost any
+preprocessing step. When a step fails, instead of marking the item not
+supported we can tell Zabbix to:
+
+- **Discard value** discards the value silently. The item stays supported and
+  no internal event is generated.
+- **Set value to** substitutes a fixed value (for example `0`).
+- **Set error to** replaces the error message with our own text.
+
+Combining the two gives a clean recipe for taming a *not supported* flood: add
+**Check for not supported value** as the first step with the error handler set
+to **Discard value**. Now, when the collection fails, the bad result is quietly
+dropped, the item never becomes *not supported*, no internal event is written,
+and the database stops growing for no reason.
+
+A few real-world examples where this is useful:
+
+- A network-interface discovery reads `/sys/class/net/<if>/speed`. For virtual
+  interfaces (WireGuard tunnels, bridges, container `veth` links) the kernel
+  returns *invalid argument* on every poll. A *Check for not supported value*
+  step set to *Discard value* stops the endless stream of internal events.
+- An SNMP hardware template polls disk or memory-module OIDs. Empty slots
+  answer with `genError`. Discarding on not supported keeps those absent
+  components quiet.
+- A dependent item extracts a metric from a Prometheus endpoint with a
+  *Prometheus pattern* step. When the source object (say a pod) disappears, the
+  pattern no longer matches and the step fails. Here the collection itself
+  succeeded, so we do not use *Check for not supported*; instead we set the
+  **error handler of the Prometheus pattern step** to *Discard value*.
+
+!!! tip "First line of defence"
+    Preprocessing fixes the symptom. The cleaner fix is often to not collect
+    the data at all: tighten your **low-level discovery filters** so virtual or
+    absent entities are never discovered, and only fall back to *Discard value*
+    for the cases you cannot filter out.
+
+A word of caution: discarding errors *hides* them. Use it deliberately, for
+entities you know are noisy and not actionable. If an item failing genuinely
+means something is wrong, you want that *not supported* state to stay visible,
+not silently swallowed.
+
+---
+
 ## Conclusion
 
 As we can see preprocessing can be used to turns raw received data into 


### PR DESCRIPTION
## Summary

Adds a new subsection **"Check for not supported value and error handlers"** to
the preprocessing page (`ch04-zabbix-collecting-data/preprocessing.md`).

The chapter already lists *Check for not supported value* among the available
preprocessing steps, but never explains it, and error handlers (*Custom on fail*)
are not documented anywhere in the book. This fills that gap.

## What it adds

- How an item failing to collect a value (SNMP error, unreadable file,
  unsupported agent key) becomes **not supported**, and how that — together with
  triggers going to **unknown** — generates **internal events** that bloat the
  `events`/`event_tag` tables and overload the housekeeper.
- The **Check for not supported value** step (runs *because* the item failed).
- **Error handlers / Custom on fail**: *Discard value*, *Set value to*,
  *Set error to*.
- The practical recipe: `Check for not supported value → Discard value` to stop
  a not-supported flood at the source.
- Three real-world examples: virtual network interfaces returning *invalid
  argument* on `/sys/class/net/<if>/speed`, empty SNMP hardware slots returning
  `genError`, and a `Prometheus pattern` step failing when the source object
  (e.g. a pod) disappears (handled via the step's own error handler, since the
  collection itself succeeded).
- A note that **LLD filters** are the cleaner first line of defence, and a
  caution that discarding errors hides them, so it should be used deliberately.

## Why

These steps are the standard, supported way to keep a large environment's
database from filling with internal-event noise, yet they are easy to miss.
Documenting them with concrete examples makes the behaviour discoverable.

## Notes

- Style follows the book conventions (prose, `### ` subsection, `!!! tip`
  admonition, ~80-column wrapping). One file changed; no images required.

## Sources

- Zabbix manual — Item value preprocessing (incl. custom error handling):
  <https://www.zabbix.com/documentation/current/en/manual/config/items/preprocessing>
- Zabbix manual — Items / item states (not supported):
  <https://www.zabbix.com/documentation/current/en/manual/config/items/item>
- Zabbix manual — Event sources (internal events):
  <https://www.zabbix.com/documentation/current/en/manual/config/events/sources>
- Zabbix manual — Low-level discovery (LLD filters):
  <https://www.zabbix.com/documentation/current/en/manual/discovery/low_level_discovery>
- Behaviour verified against a large production environment (k8s/SNMP templates
  generating millions of internal events/day from virtual or absent entities).
