### PR TITLE
Ch13 - Add Suse instructions

### DIFF
--- a/docs/ch01-zabbix-components/postgresql.md
+++ b/docs/ch01-zabbix-components/postgresql.md
@@ -34,6 +34,12 @@ a good idea to go with the latest version that is supported by Zabbix.
     If you choose to install PostgreSQL from the OS vendor-provided packages,
     you will need to compile and install the TimescaleDB extension from source.
 
+    Extra note: TimescaleDB doest not provide packages for SUSE Linux Enterprise
+    Server (SLES) or openSUSE Leap. Instead Suse provides the TimescaleDB 
+    extension in their own repositories. But for that to work you will need to
+    install PostgreSQL from the OS vendor-provided packages instead of the official
+    PostgreSQL repositories.
+
 ---
 
 ## Installing PostgreSQL Server and Client from OS Vendor-Provided Packages

--- a/docs/ch13-advanced-security/partitioning-database.md
+++ b/docs/ch13-advanced-security/partitioning-database.md
@@ -68,11 +68,17 @@ installed onto your database server yet, do that now.
 !!! info "Check disk space availability"
 
     Red Hat-based
-    ```
+    ```bash
     dnf install tmux
     ```
-    Debian-based
+
+    SUSE
+    ```bash
+    zypper install tmux
     ```
+
+    Debian-based
+    ```bash
     apt install tmux
     ```
 
@@ -80,7 +86,7 @@ Now we can issue the tmux command to open a new tmux session:
 
 !!! info "Open tmux session"
 
-    ```
+    ```bash
     tmux
     ```
 
@@ -197,7 +203,8 @@ to use the `tmux` command as we mentioned earlier.
 
 !!! info "Login to MariaDB"
 
-    ```mariadb -u root -p
+    ```bash
+    mariadb -u root -p
     ```
 
 Execute the history and trends partitioning commands you prepared in your notepad
@@ -219,14 +226,16 @@ in the following folder:
 
 !!! info "Script folder (create the folder if it doesn't exist)"
 
-    ```/usr/lib/zabbix/
+    ```bash
+    mkdir -p /usr/lib/zabbix/
     ```
 
 Then make the script executable, so we can create a cronjob later to execute it.
 
 !!! info "Make the script executable"
 
-    ```chmod 750 /usr/lib/zabbix/mysql_zbx_part.pl
+    ```bash
+    chmod 750 /usr/lib/zabbix/mysql_zbx_part.pl
     ```
 
 Now, let's make sure all the settings in the script are set-up correctly. Edit the
@@ -234,7 +243,8 @@ script with your favourite editor (yes, nano is also an option).
 
 !!! info "Edit the script"
 
-    ```vim /usr/lib/zabbix/mysql_zbx_part.pl
+    ```bash
+    vim /usr/lib/zabbix/mysql_zbx_part.pl
     ```
 
 There are a few lines here we need to edit to make sure the script works. Let's start
@@ -242,7 +252,7 @@ with our MariaDB login details.
 
 !!! info "Add login details to the script"
 
-    ```
+    ```bash
     my $dsn = 'DBI:mysql:'.$db_schema.':mysql_socket=/var/lib/mysql/mysql.sock';
 
     my $db_user_name = 'zabbix';
@@ -264,7 +274,7 @@ We define that in the following block.
 
 !!! info "Add login details to the script"
 
-    ```
+    ```bash
     my $tables = {  'history' => { 'period' => 'day', 'keep_history' => '31'},
 
                     'history_log' => { 'period' => 'day', 'keep_history' => '31'},
@@ -289,7 +299,8 @@ database server. As this was written in the the Netherlands, I will use `Europe/
 
 !!! info "Add correct timezone"
 
-    ```my $curr_tz = 'Europe/Amsterdam';
+    ```bash
+    my $curr_tz = 'Europe/Amsterdam';
     ```
 
 Then the last important step is to make sure that we comment or uncomment some lines
@@ -303,7 +314,7 @@ to do anything.
 For the `MySQL 8.x` users comment the following `MariaDB` lines.
 !!! info "Comment MariaDB"
 
-    ```
+    ```bash
     # MySQL 5.6 + MariaDB
 
         #my $sth = $dbh->prepare(qq{SELECT plugin_status FROM information_schema.plugins
@@ -324,7 +335,7 @@ For the `MySQL 8.x` users comment the following `MariaDB` lines.
 And uncomment the `MySQL 8.x` lines.
 !!! info "Uncomment MySQL 8.x"
 
-    ```
+    ```bash
     # MySQL 8.x (NOT MariaDB!)
 
         my $sth = $dbh->prepare(qq{select version();});
@@ -346,7 +357,7 @@ But do not do this for Zabbix 6.0 and higher though.
 
 !!! info "Uncomment for Zabbix 5.4 and older only"
 
-    ```
+    ```bash
     # Uncomment the following line for Zabbix 5.4 and earlier
 
         # $dbh->do("DELETE FROM auditlog_details WHERE NOT EXISTS (SELECT NULL FROM
@@ -360,7 +371,8 @@ Do not do this for Zabbix 7.0 and higher though:
 
 !!! info "Uncomment for Zabbix 6.4 and older only"
 
-    ```'history_bin' => { 'period' => 'day', 'keep_history' => '60'},
+    ```bash
+    'history_bin' => { 'period' => 'day', 'keep_history' => '60'},
     ```
 
 We also need to install some Perl dependencies to make sure we can execute the script.
@@ -368,11 +380,19 @@ We also need to install some Perl dependencies to make sure we can execute the s
 !!! info "Install dependencies"
 
     Red Hat-Based
-    ```
+    ```bash
     dnf install perl-DateTime perl-Sys-Syslog
     ```
-    Debian-based
+
+    SUSE
+    ```bash
+    zypper install perl-DateTime
     ```
+    note: on SUSE, the Sys::Syslog module is included in the perl package, so no 
+    separate installation is needed.
+
+    Debian-based
+    ```bash
     apt-get install libdatetime-perl liblogger-syslog-perl
     ```
 
@@ -382,22 +402,22 @@ the powertools repo.
 !!! info "Install correct repository"
 
     Red Hat 7 based
-    ```
+    ```bash
     yum config-manager --set-enabled powertools
     ```
 
     Red Hat 9 based
-    ```
+    ```bash
     dnf config-manager --enable crb
     ```
 
     Genuine Red Hat
-    ```
+    ```bash
     subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
     ```
 
     Oracle Linux
-    ```
+    ```bash
     dnf config-manager --set-enabled ol8_codeready_builder
     ```
 
@@ -405,28 +425,32 @@ Then the last step is to add a cronjob to execute the script everyday.
 
 !!! info "Open crontab"
 
-    ```crontab -e
+    ```bash
+    crontab -e
     ```
 
 Add the following line to create the cronjob.
 
 !!! info "Create cronjob"
 
-    ```55 22 * * * /usr/lib/zabbix/mysql_zbx_part.pl >/dev/null 2>&1
+    ```bash
+    55 22 * * * /usr/lib/zabbix/mysql_zbx_part.pl >/dev/null 2>&1
     ```
 
 Execute the script manually to test.
 
 !!! info "Manual script execution for testing"
 
-    ```perl /usr/lib/zabbix/mysql_zbx_part.pl
+    ```bash
+    perl /usr/lib/zabbix/mysql_zbx_part.pl
     ```
 
 Then we can check and see if it worked.
 
 !!! info "Check the script log"
 
-    ```journalctl -t mysql_zbx_part
+    ```bash
+    journalctl -t mysql_zbx_part
     ```
 
 This will give you back a list of created and deleted partitions if you've done

--- a/docs/ch13-advanced-security/partitioning-postgresql-database.md
+++ b/docs/ch13-advanced-security/partitioning-postgresql-database.md
@@ -361,7 +361,7 @@ TimescaleDB extension and apply the new settings.:
     ```
 ---
 
-### Configure Zabbix for timescaledb
+### Enable TimescaleDB extension in Zabbix database
 
 Next, we connect to the Zabbix database as the user `zabbixsrv`, or whichever database
 user you have configured earlier, and create the TimescaleDB extension. However,
@@ -403,7 +403,11 @@ Make sure the extension is installed by running `\dx`.
 
 ### Patch Zabbix database
 
-While still connected to the Zabbix database, you can now apply the TimescaleDB
+To patch the Zabbix database for TimescaleDB, you will need to run the `schema.sql` script
+provided by Zabbix in the `zabbix-sql-scripts` package. Make sure you have this
+package installed on your system, refer to [Chapter 0 - Getting Started: Preparing the system for Zabbix](../ch00-getting-started/preparation.md#install-the-zabbix-repository) to configure the Zabbix repository.
+
+With `zabbix-sql-scripts` installed, you can now apply the TimescaleDB
 patch. This patch will migrate your existing history, trends, and audit log tables
 to the TimescaleDB format. Depending on the amount of existing data, this process
 may take some time.

--- a/docs/ch13-advanced-security/partitioning-postgresql-database.md
+++ b/docs/ch13-advanced-security/partitioning-postgresql-database.md
@@ -17,6 +17,8 @@ TimescaleDB takes care of the underlying logic, freeing you from custom scripts
 and manual tweaks. For this reason, PostgreSQL could be the preferred and most convenient
 option for managing large scale Zabbix environments.
 
+---
+
 ## Installing TimescaleDB
 
 First, make sure to download TimescaleDB from the correct source: [https://docs.timescale.com/self-hosted/latest/install/](https://docs.timescale.com/self-hosted/latest/install/).
@@ -30,11 +32,35 @@ essential for efficient long term data storage and performance in larger environ
 
 ???+ info
 
-    To use TimescaleDB with Zabbix, make sure PostgreSQL is installed from the official
-    PostgreSQL community repositories, as described in our setup guide. **Do not**
-    use the PostgreSQL version provided by Red Hat or its derivatives. The TimescaleDB
-    extension is not compatible with that version, and attempting to use it will
-    lead to failure in the configuration.
+    When using TimescaleDB with Zabbix on Red Hat or its derivatives, make sure
+    PostgreSQL is installed from the official PostgreSQL community repositories,
+    as described in our setup guide. **Do not** use the PostgreSQL version provided 
+    by Red Hat or its derivatives. The TimescaleDB extension is not compatible
+    with that version, and attempting to use it will lead to failure in the
+    configuration.
+
+    For SUSE Linux it is another story. TimescaleDB does not provide packages for
+    SUSE Linux. On SLES 15, the TimescaleDB extension is included in the official
+    SUSE PackageHub repositories and on openSUSE Tumbleweed it is available as well.
+    But for that to work you DO need to install PostgreSQL from the OS vendor-provided
+    packages instead of the official PostgreSQL repositories.
+
+    Unfortunately, TimescaleDB seems not to be the available for openSUSE Leap and SLES 16.
+    For those systems, you can add the SUSE Factory server:database:postgresql 
+    repository to your system and install TimescaleDB from there. However, the
+    chances are high that this version will require also the Postgresql packages from
+    that same SUSE Factory repository. Overall this should not be a problem on 
+    openSUSE, but on SLES, if you have paid support for PostgreSQL via SUSE, 
+    this will break your support contract. In that case your only option is to
+    compile TimescaleDB from source against the SUSE supported PostgreSQL package.
+
+    Warning: Due to licensing restrictions, TimescaleDB packages provided by SUSE uses the
+    Apache license instead of the Community edition. This means that some features
+    like native compression are not available. If you require these features, you
+    will need to compile TimescaleDB from source. In that case it won't matter
+    if you installed PostgreSQL from the official PostgreSQL repositories or from the
+    OS vendor-provided packages, as you will be compiling TimescaleDB against the
+    PostgreSQL version you have installed.
 
 ???+ note
 
@@ -43,12 +69,14 @@ essential for efficient long term data storage and performance in larger environ
     way you don't install any unsupported version that could run you into issues.
     [https://docs.timescale.com/self-hosted/latest/install/installation-linux/#supported-platforms](https://docs.timescale.com/self-hosted/latest/install/installation-linux/#supported-platforms)
 
+---
+
 ### Add the TimescaleDB repository
 
 !!! info "adding the repository"
 
     Red Hat
-    ```
+    ```bash
     sudo tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
     [timescale_timescaledb]
     name=timescale_timescaledb
@@ -62,34 +90,77 @@ essential for efficient long term data storage and performance in larger environ
     metadata_expire=300
     EOL
     ```
-    Ubuntu
+
+    SLES 15 SP7
+    ```bash
+    SUSEConnect -p PackageHub/15.7/x86_64
     ```
+
+    SLES 16 and openSUSE Leap 16.0
+    ```bash
+    zypper addrepo --refresh https://download.opensuse.org/repositories/server:/database:/postgresql/16.0/server:database:postgresql.repo
+    ```
+    (You can check https://download.opensuse.org/repositories/server:/database:/postgresql/
+    which SUSE versions are available and adjust the version in the above URL accordingly.)
+
+    Ubuntu
+    ```bash
     echo "deb https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/timescaledb.list
     ```
-    ```
+    ```bash
     wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey |
-     sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/timescaledb.gpg
+    sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/timescaledb.gpg
     ```
 
 !!! info "Update your local repository list"
 
     Red Hat
-    ```
-    sudo dnf update -y
-    ```
-    Ubuntu
-    ```
-    sudo apt update -y
+    ```bash
+    dnf update -y
     ```
 
-### Install TimescaleDB
+    SUSE
+    ```bash
+    zypper --gpg-auto-import-keys refresh
+    ```
+
+    Ubuntu
+    ```bash
+    sudo apt update -y
+    ```
+---
+
+### Install TimescaleDB from package
+
+We will now install the TimescaleDB externsion using the package manager, either
+from the official TimescaleDB repository for Red Hat and Ubuntu, or from the 
+SUSE PackageHub or SUSE Factory repository for SLES and openSUSE. 
+If you prefer to compile TimescaleDB from source, for example if you want the 
+Community edition on SUSE or if you are using a different Linux flavor not
+supported by TimescaleDB, you can follow the instructions in the next section.
 
 !!! info "Install TimescaleDB"
 
     Red Hat
+    ```bash
+    dnf install timescaledb-2-postgresql-17 postgresql-client-17
     ```
-    sudo yum install timescaledb-2-postgresql-17 postgresql17
+
+    SLES 15 SP7
+    ```bash
+    zypper install postgresql17-timescaledb
     ```
+
+    SLES 16 and openSUSE Leap 16.0
+    ```bash
+    zypper install --allow-vendor-change postgresql17-timescaledb
+    ```
+    Note: the `--allow-vendor-change` option is required because the TimescaleDB package
+    is provided by the SUSE Factory repository, which is considered a different
+    vendor than the official SUSE repositories. This option allows zypper to replace
+    the PostgreSQL package from the official SUSE repository with the one from the
+    SUSE Factory repository, which is necessary for TimescaleDB to work correctly.
+
     Ubuntu
     ```
     sudo apt install timescaledb-2-postgresql-17 postgresql-client-17
@@ -107,38 +178,112 @@ essential for efficient long term data storage and performance in larger environ
     Using mismatched versions can lead to compatibility issues, so always make
     sure the TimescaleDB packages align with your PostgreSQL version.
 
+    Make sure to replace all version numbers in the commands in this chapter
+    with the version of PostgreSQL you have installed.
+
 ???+ warning
 
-    ```
     Be sure to install the version of TimescaleDB that is supported by Zabbix
     also when you upgrade your OS verify that the new database version and
     timescaledb are supported by Zabbix. It's probably best to exclude them from
-    automatic updates.
-    ```
+    automatic updates. Do note however that this will also prevent you from
+    getting newer postgresql packages as each timescaledb package is built against
+    a specific postgresql package. So you may see errors during system updates
+    when a newer postgresql package is available but the installed locked timescaledb
+    has a requirement for the older postgresql package.
 
 !!! info "Check for specific versions"
 
     Red Hat
-    ```
+    ```bash
     dnf list timescaledb-2-postgresql-17 --showduplicates
     ```
-    Ubuntu
+
+    SUSE
+    ```bash
+    zypper search -v postgresql17-timescaledb
     ```
+
+    Ubuntu
+    ```bash
     apt-cache policy timescaledb-2-postgresql-17
     ```
 
 !!! info "installing a specific version and lock the version"
 
     Red Hat
+    ```bash
+    dnf install timescaledb-2-postgresql-17-2.19.3
+    dnf versionlock add timescaledb-2-postgresql-17
     ```
-    sudo dnf install timescaledb-2-postgresql-17-2.19.3
-    sudo dnf versionlock add timescaledb-2-postgresql-17
+
+    SUSE
+    ```bash
+    zypper install postgresql17-timescaledb-2.29.1
+    zypper addlock postgresql17-timescaledb
     ```
+    Warning: on SLES15 using PackageHub you have all versions starting from the
+    version that was originally shipped with SLES15 up to the most recent version.
+    When using the SUSE Factory server:database:postgresql repository on SLES16 
+    and openSUSE Leap you will always only have the latest built version available.
+    On those systems, you can still lock the current version preventing it from
+    being updated. But if you ever remove or upgrade the package, you won't be 
+    able to go back.
+
     Ubuntu
-    ```
+    ```bash
     sudo apt install timescaledb-2-postgresql-17=2.19.3~ubuntu24.04 timescaledb-2-loader-postgresql-17=2.19.3~ubuntu24.04
     sudo apt-mark hold timescaledb-2-postgresql-17
     ```
+---
+
+### Compile TimescaleDB from source
+
+If you already installed TimescaleDB from packages, you can skip this section.
+If you prefer to compile TimescaleDB from source, make sure to first uninstall
+any existing TimescaleDB packages.
+
+First, we need to install the required dependencies for building TimescaleDB:
+
+!!! info "Install build dependencies"
+
+    Red Hat
+    ```bash
+    dnf install -y git cmake gcc-c++ make postgresql17-devel libicu-devel
+    ```
+
+    SUSE
+    ```bash
+    zypper install -y git cmake gcc-c++ make postgresql17-server-devel libicu-devel
+    ```
+
+    Ubuntu
+    ```bash
+    sudo apt install -y git cmake g++ make postgresql-server-dev-17 libicu-dev
+    ```
+
+Next we will download the TimescaleDB source code from the official GitHub 
+repository and check out a version that is supported by Zabbix:
+
+!!! info "Download TimescaleDB source code"
+
+    ```bash
+    git clone https://github.com/timescale/timescaledb
+    cd timescaledb
+    git checkout 2.19.3
+    ```
+
+Now it is time to actually build and install TimescaleDB:
+
+!!! info "Build and install TimescaleDB"
+
+    ```bash
+    ./bootstrap
+    cd build && make
+    sudo make install
+    ```
+
+---
 
 ### Configure TimescaleDB
 
@@ -153,6 +298,20 @@ settings to optimize performance. On Red Hat based systems, you can run:
 
     ```bash
     sudo timescaledb-tune --pg-config=/usr/pgsql/17/bin/pg_config
+    ```
+
+When installed on SUSE using the SUSE packages, the script is not available and 
+you will need to install it manually using Go. Additionally, the `pg_config` binary
+is part of the `postgresql17-server-devel` package, which is not installed by default.
+So we will install both packages, use Go to install the tuning script, and then
+run it to tune your PostgreSQL configuration.:
+
+!!! info
+
+    ```bash
+    zypper install postgresql17-server-devel go
+    go install github.com/timescale/timescaledb-tune/cmd/timescaledb-tune@main
+    /root/go/bin/timescaledb-tune -conf-path=/var/lib/pgsql/data/postgresql.conf
     ```
 
 For Ubuntu and Debian based systems, simply run:
@@ -176,22 +335,31 @@ At a minimum, make sure to add the following line at the end of the file:
     shared_preload_libraries = 'timescaledb'
     ```
 
-!!! info "Let's load the library"
+    Your PostgreSQL configuration file is typically located at `/var/lib/pgsql/17/data/postgresql.conf` 
+    on Red Hat based systems, `/var/lib/pgsql/data/postgresql.conf` on SUSE, and 
+    `/etc/postgresql/17/main/postgresql.conf` on Ubuntu.
+
+After making these changes to your PostgreSQL configuration, either manually or 
+using the tuning script, you must restart the PostgreSQL service to load the 
+TimescaleDB extension and apply the new settings.:
+
+!!! info "Restart PostgreSQL service"
 
     Red Hat
-    ```
-    echo "shared_preload_libraries = 'timescaledb'" | sudo tee -a /var/lib/pgsql/17/data/postgresql.conf
-    ```
-    ```
+    ```bash
     systemctl restart postgresql-17
     ```
+
+    SUSE
+    ```bash
+    systemctl restart postgresql
+    ```
+
     Ubuntu
-    ```
-    echo "shared_preload_libraries = 'timescaledb'" | sudo tee -a /etc/postgresql/17/main/postgresql.conf
-    ```
-    ```
+    ```bash
     sudo systemctl restart postgresql
     ```
+---
 
 ### Configure Zabbix for timescaledb
 
@@ -203,29 +371,24 @@ could otherwise cause locks or unexpected behavior.
 
 !!! info "Stop Zabbix server"
 
-    Red Hat and Ubuntu
     ```bash
     sudo systemctl stop zabbix-server
     ```
 
 !!! info "Create timescaledb extension"
 
-    Red Hat and Ubuntu
     ```bash
     psql -Uzabbix-srv zabbix -W
     ```
-    ```
-    psql (17.5)
-    Type "help" for help.
-
-    zabbix=> CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
+    ```sql
+    CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
     ```
 
 Make sure the extension is installed by running `\dx`.
 
 !!! info ""
 
-    ```
+    ```shell-session
     zabbix=> \dx
                                                 List of installed extensions
     Name     | Version |   Schema   |                                      Description
@@ -236,6 +399,7 @@ Make sure the extension is installed by running `\dx`.
 
     zabbix=>
     ```
+---
 
 ### Patch Zabbix database
 
@@ -248,9 +412,27 @@ Run the following command inside the database session:
 
 !!! info ""
 
-    ```sql
+    ```shell-session
     zabbix=> \i /usr/share/zabbix/sql-scripts/postgresql/timescaledb/schema.sql
     ```
+
+???+ warning
+
+    When running the `schema.sql` script on TimescaleDB version 2.9.0 or higher,
+    you may see warning messages indicating that certain best practices are not
+    being followed. These warnings can be safely ignored. They do not affect the
+    outcome of the configuration process.
+
+    As long as everything is set up correctly, the script will complete without
+    issue. You should see the following confirmation at the end:
+
+    ```shell-session
+    psql:/usr/share/zabbix/sql scripts/postgresql/timescaledb/schema.sql:112:
+    NOTICE:  TimescaleDB is configured successfully
+    ```
+
+    This confirms that the TimescaleDB extension and related Zabbix settings have
+    been applied correctly.
 
 The `schema.sql` script adjusts several important housekeeping parameters:
 
@@ -271,8 +453,7 @@ Let's start our zabbix server again before we continue
 
 !!! info "start Zabbix server"
 
-    RedHat and Ubuntu
-    ```
+    ```bash
     sudo systemctl start zabbix-server
     ```
 
@@ -283,25 +464,7 @@ Let's have a look at them go in our menu to **Administration** -> **Housekeeping
 _13.12 housekeeper
 settings_
 
-???+ warning
-
-    ```
-    When running the `schema.sql` script on TimescaleDB version 2.9.0 or higher,
-    you may see warning messages indicating that certain best practices are not
-    being followed. These warnings can be safely ignored. They do not affect the
-    outcome of the configuration process.
-
-    As long as everything is set up correctly, the script will complete without
-    issue. You should see the following confirmation at the end:
-    ```
-    ```sql
-    psql:/usr/share/zabbix/sql scripts/postgresql/timescaledb/schema.sql:112:
-    NOTICE:  TimescaleDB is configured successfully
-    ```
-    ```
-    This confirms that the TimescaleDB extension and related Zabbix settings have
-    been applied correctly.
-    ```
+---
 
 ## Conclusion
 
@@ -315,6 +478,8 @@ the TimescaleDB schema patch, you ensure that Zabbix can scale reliably with min
 maintenance overhead. This setup not only optimizes performance but also prepares
 your environment for long term growth and data retention.
 
+---
+
 ## Questions
 
 - What are the key advantages of using TimescaleDB compared to partitioning with
@@ -322,6 +487,8 @@ your environment for long term growth and data retention.
 - What might go wrong if you install PostgreSQL from the default Red Hat repositories
   when planning to use TimescaleDB?
 - How does enabling compression in TimescaleDB benefit your Zabbix installation?
+
+---
 
 ## Useful URLs
 

--- a/docs/ch13-advanced-security/storing-data-in-clickhousedb.md
+++ b/docs/ch13-advanced-security/storing-data-in-clickhousedb.md
@@ -22,6 +22,8 @@ In this chapter, you will install ClickHouse and configure it for use with
 Zabbix 8, import the required history schema, and verify that Zabbix is successfully
 storing history in ClickHouse.
 
+---
+
 ## What Moves to ClickHouse ...  and What Doesn't
 
 ClickHouse stores the raw item history values for the value types assigned
@@ -65,36 +67,142 @@ _13.13 Zabbix ClickHouse history storage architecture_
 
 With that distinction in mind, let's set up the backend.
 
+---
+
 ## Lab Environment
 
 The examples in this chapter were tested using:
 
-* Rocky Linux 9
+* Rocky Linux 9 and openSUSE Leap 16.0
 * ClickHouse 26.6.1.1193
 * Zabbix 8
+
+but should work with any recent Red Hat or SUSE derivative.
+
+---
 
 ## Installing ClickHouse
 
 Begin by installing the official ClickHouse repository and packages.
 
-```bash
-dnf install -y dnf-plugins-core
-dnf config-manager --add-repo https://packages.clickhouse.com/rpm/clickhouse.repo
-dnf install -y clickhouse-server clickhouse-client
-```
+!!! info "Installing ClickHouse"
+
+    Red Hat
+    ```bash
+    dnf install -y dnf-plugins-core
+    dnf config-manager --add-repo https://packages.clickhouse.com/rpm/clickhouse.repo
+    dnf install -y clickhouse-server clickhouse-client
+    ```
+
+    SUSE
+    ```bash
+    zypper addrepo --refresh --gpgcheck https://packages.clickhouse.com/rpm/clickhouse.repo
+    zypper --gpg-auto-import-keys refresh clickhouse-stable
+    zypper install clickhouse-server clickhouse-client
+    ```
+
+Before starting ClickHouse, we need to tune the system for optimal performance.
+
+1. **Hugepages**
+   Clickhouse does not use hugepages and requires it to be disabled. 
+   On SUSE, transparent hugepages are enabled by default. 
+   
+   You can check the current status with:
+
+   ```shell-session
+   cat /sys/kernel/mm/transparent_hugepage/enabled
+   ```
+   You will see something like:
+
+   ```text
+   [always] madvise never
+   ```
+   The value in brackets indicates the current setting. If it is set to `always`,
+   you need to set it to `madvise` or to `never`.
+
+   To disable it, edit `/etc/default/grub` and add the `transparent_hugepage=never`
+   parameter at the end of the `GRUB_CMDLINE_LINUX_DEFAULT` variable:
+
+   ```ini
+   GRUB_CMDLINE_LINUX_DEFAULT="... transparent_hugepage=never"
+   ```
+
+   Then update the grub configuration and reboot the system:
+
+   ```bash
+   grub2-mkconfig -o /boot/grub2/grub.cfg
+   reboot
+   ```
+
+2. **Delay accounting**
+   ClickHouse requires Kernel delay accounting to be enabled. On SUSE, delay
+   accounting is disabled by default. You can check the current status with:
+
+   ```bash
+   cat /sys/kernel/debug/delayacct
+   ```
+   If it displays `0`, it is disabled and you need to enable it.
+
+   Create a new file `/etc/sysctl.conf.d/99-clickhouse.conf` and add the following line:
+
+   ```ini
+    # Enable delay accounting
+    kernel.task_delayacct = 1
+    ```
+    
+    Then apply the changes:
+    
+    ```bash
+    sysctl -p /etc/sysctl.conf.d/99-clickhouse.conf
+    ```
+
+3. **Number of threads**
+   ClickHouse is a multi-threaded application and requires a sufficient number
+   of threads to be available. On SUSE, the default max. number of threads is 15574
+   however, ClickHouse requires at least 30000.
+   To ensure that the ClickHouse-server service has enough threads, create a 
+   new systemd override file:
+
+   ```bash
+   systemctl edit clickhouse-server
+   ```
+   and add the following lines:
+
+   ```ini
+   [Service]
+   LimitNPROC=30000
+   ```
 
 Enable the ClickHouse service so it starts automatically at boot.
 
-```bash
-systemctl enable clickhouse-server
-systemctl start clickhouse-server
-```
+!!! info "Enabling ClickHouse service"
+
+    ```bash
+    systemctl enable clickhouse-server
+    systemctl start clickhouse-server
+    ```
+    Note: On Red Hat and SUSE 15, the above commands work as expected. However, on
+    SUSE 16, the helper script `systemd-sysv-install` is not available as SysV init
+    compatibility is removed on that platform. This will cause `systemctl enable
+    clickhouse-server` to fail. Therefore we need to use the full path to the systemd
+    service file to ignore the SysV init script and enable the systemd service directly:
+
+    ```bash
+    systemctl enable /lib/systemd/system/clickhouse-server.service
+    ```
+
+    This will probably be fixed in a future SUSE release as from SystemD 260,
+    SysV init compatibility will also be removed from systemd itself, but for
+    now Suse ships SystemD 257.
 
 Verify that the service is running before continuing.
 
-```bash
-systemctl status clickhouse-server
-```
+!!! info "Verifying ClickHouse service"
+
+    ```bash
+    systemctl status clickhouse-server
+    ```
+---
 
 ## Configuring ClickHouse
 
@@ -102,21 +210,23 @@ By default, ClickHouse only listens on the loopback interface. That's fine when
 Zabbix and ClickHouse run on the same host, but many environments use a dedicated
 ClickHouse server or cluster instead.
 
-Create the following configuration file:
+!!! info "Configuring ClickHouse to listen on all interfaces"
 
-`/etc/clickhouse-server/config.d/listen.xml`
+    Create the following configuration file:
+    `/etc/clickhouse-server/config.d/listen.xml`
 
-```xml
-<clickhouse>
-    <listen_host>0.0.0.0</listen_host>
-</clickhouse>
-```
+    ```xml
+    <clickhouse>
+        <listen_host>0.0.0.0</listen_host>
+    </clickhouse>
+    ```
 
-Reload the configuration by restarting ClickHouse.
+    Reload the configuration by restarting ClickHouse.
 
-```bash
-systemctl restart clickhouse-server
-```
+    ```bash
+    systemctl restart clickhouse-server
+    ```
+---
 
 ## Correcting Filesystem Permissions
 
@@ -126,92 +236,120 @@ creation.
 
 Ensure the directory has the correct ownership and permissions.
 
-```bash
-chown -R clickhouse:clickhouse /var/lib/clickhouse
-chmod 0750 /var/lib/clickhouse
-restorecon -Rv /var/lib/clickhouse
-```
+!!! info "Correcting ClickHouse data directory permissions"
+
+    ```bash
+    chown -R clickhouse:clickhouse /var/lib/clickhouse
+    chmod 0750 /var/lib/clickhouse
+    restorecon -Rv /var/lib/clickhouse
+    ```
+
+---
 
 ## Creating the Database
 
 Connect to ClickHouse:
 
-```bash
-clickhouse-client
-```
+!!! info "Connecting to ClickHouse"
+
+    ```bash
+    clickhouse-client
+    ```
 
 Create the Zabbix database:
 
-```sql
-CREATE DATABASE zabbix;
-```
+!!! info "Creating the Zabbix database"
+
+    ```sql
+    CREATE DATABASE zabbix;
+    ```
+
+---
 
 ## Creating the Zabbix User
 
 Create a dedicated database user for Zabbix:
 
-```sql
-CREATE USER zabbix
-IDENTIFIED WITH sha256_password
-BY 'zabbix';
-```
+!!! info "Creating the Zabbix user"
+
+    ```sql
+    CREATE USER zabbix
+    IDENTIFIED WITH sha256_password
+    BY 'zabbix';
+    ```
 
 Grant the required privileges:
 
-```sql
-GRANT CREATE, ALTER, DROP, INSERT, SELECT, UPDATE, OPTIMIZE
-ON zabbix.* TO zabbix;
-```
+!!! info "Granting privileges"
+
+    ```sql
+    GRANT CREATE, ALTER, DROP, INSERT, SELECT, UPDATE, OPTIMIZE
+    ON zabbix.* TO zabbix;
+    ```
 
 Exit the client and verify connectivity over HTTP:
 
-```bash
-curl -u zabbix:zabbix \
-"http://127.0.0.1:8123/?database=zabbix&query=SELECT%201"
-```
+!!! info "Verifying HTTP connectivity"
+
+    ```bash
+    curl -u zabbix:zabbix \
+    "http://127.0.0.1:8123/?database=zabbix&query=SELECT%201"
+    ```
 
 The command should return:
 
-``` bash
-1
-```
+!!! example "Expected output"
+
+    ```text
+    1
+    ```
 
 This confirms the HTTP interface is working and the user has sufficient permissions.
 
+---
+
 ## Importing the Zabbix History Schema
 
-The Zabbix source distribution contains helper scripts that automatically create
-the required ClickHouse tables.
+The Zabbix package `zabbix-sql-scripts` contains helper scripts that automatically create
+the required ClickHouse tables. Refer to [Chapter 0 - Getting Started: Preparing the system for Zabbix](../ch00-getting-started/preparation.md#install-the-zabbix-repository)
+to install the Zabbix repository and then install the `zabbix-sql-scripts` package.
 
 Navigate to the ClickHouse database scripts:
 
-```bash
-cd database/clickhouse
-```
+!!! info "Importing the Zabbix history schema"
 
-Execute each schema script:
+    Navigate to the directory containing the ClickHouse schema scripts installed
+    by the `zabbix-sql-scripts` package:
 
-```bash
-./history_schema.sh \
-    --server http://127.0.0.1:8123 \
-    --db zabbix \
-    --user zabbix \
-    --password zabbix
-```
+    ```bash
+    cd /usr/share/zabbix/sql-scripts/clickhouse
+    ```
 
-Repeat the process for the remaining history types:
+    Execute each schema script:
 
-``` bash
-history_uint_schema.sh
-history_str_schema.sh
-history_text_schema.sh
-history_log_schema.sh
-history_json_schema.sh
-```
-You can also use `history_all.sh` instead of running the script one by one.
+    ```bash
+    ./history_schema.sh \
+        --server http://127.0.0.1:8123 \
+        --db zabbix \
+        --user zabbix \
+        --password zabbix
+    ```
+
+    Repeat the process for the remaining history types:
+
+    ``` bash
+    history_uint_schema.sh
+    history_str_schema.sh
+    history_text_schema.sh
+    history_log_schema.sh
+    history_json_schema.sh
+    ```
+    You can also use `history_all.sh` instead of running the script one by one.
 
 Once complete, ClickHouse will contain a separate table for every supported Zabbix
 history value type.
+
+---
 
 ## Configuring Retention and Partitioning
 
@@ -224,17 +362,20 @@ Each history table includes a Time-To-Live (TTL) expression that automatically
 removes old history data. By default, the scripts retain history for 31
 days (2,678,400 seconds).
 
-To retain history for 90 days instead, specify:
+!!! info "Setting a custom retention period"
 
-```bash
---ttl 7776000
-```
+    To retain history for 90 days instead, specify this extra parameter to the
+    scripts:
 
-The generated table will include:
+    ```bash
+    --ttl 7776000
+    ```
 
-```sql
-TTL clock_ns + toIntervalSecond(7776000)
-```
+    The generated table will include:
+
+    ```sql
+    TTL clock_ns + toIntervalSecond(7776000)
+    ```
 
 Unlike traditional databases, ClickHouse removes expired data automatically during
 background merge operations, there's no housekeeping job to schedule or monitor.
@@ -243,27 +384,32 @@ background merge operations, there's no housekeeping job to schedule or monitor.
 
 The default partitioning strategy creates one partition per day:
 
-```bash
---partition toDate
-```
+!!! info "Daily partitions"
+
+    ```bash
+    --partition toDate
+    ```
 
 Daily partitions work well for smaller installations, but can result in a very
 large number of partitions over time. Larger environments generally benefit
 from monthly partitions instead:
 
-```bash
---partition toYYYYMM
-```
+!!! info "Monthly partitions"
 
-This produces tables similar to:
+    Add this extra parameter to the schema generation scripts:
+    ```bash
+    --partition toYYYYMM
+    ```
 
-```sql
-ENGINE = MergeTree
-PARTITION BY toYYYYMM(clock_ns)
-PRIMARY KEY (itemid, clock_ns)
-ORDER BY (itemid, clock_ns)
-TTL clock_ns + toIntervalSecond(7776000)
-```
+    This produces tables similar to:
+
+    ```sql
+    ENGINE = MergeTree
+    PARTITION BY toYYYYMM(clock_ns)
+    PRIMARY KEY (itemid, clock_ns)
+    ORDER BY (itemid, clock_ns)
+    TTL clock_ns + toIntervalSecond(7776000)
+    ```
 
 Monthly partitions typically strike the best balance between:
 
@@ -275,68 +421,84 @@ Monthly partitions typically strike the best balance between:
 For most production deployments, monthly partitions combined with an appropriate
 TTL are recommended.
 
-**Example:**
+!!! eample "Importing the history schema with a 90-day retention and monthly partitions"
 
-```bash
-./history_uint_schema.sh \
-    --server http://127.0.0.1:8123 \
-    --db zabbix \
-    --user zabbix \
-    --password zabbix \
-    --ttl 7776000 \
-    --partition toYYYYMM
-```
+    ```bash
+    ./history_uint_schema.sh \
+        --server http://127.0.0.1:8123 \
+        --db zabbix \
+        --user zabbix \
+        --password zabbix \
+        --ttl 7776000 \
+        --partition toYYYYMM
+    ```
+
+---
 
 ## Configuring Zabbix
 
-Edit the Zabbix server configuration file:
+Create the Zabbix server configuration file:
 
-`/etc/zabbix/zabbix_server.conf`
+`/etc/zabbix/zabbix_server.conf.d/clickhouse.conf`
 
-Configure ClickHouse as the history provider:
+!!! info "Zabbix server configuration"
 
-```
-HistoryProvider=clickhouse;value_types="uint,dbl,str,log,text,json",url=http://127.0.0.1:8123,db=zabbix,username=zabbix,password="zabbix"
-```
+    Configure ClickHouse as the history provider:
 
-When using ClickHouse 26.6 or another version newer than officially supported,
-also set:
+    ```ini
+    HistoryProvider=clickhouse;value_types="uint,dbl,str,log,text,json",url=http://127.0.0.1:8123,db=zabbix,username=zabbix,password="zabbix"
+    ```
 
-```
-AllowUnsupportedDBVersions=1
-```
+    When using ClickHouse 26.6 or another version newer than officially supported,
+    also set:
+
+    ```ini
+    AllowUnsupportedDBVersions=1
+    ```
 
 Save the configuration file.
+
+---
 
 ## Verifying the Configuration
 
 Before restarting the server, validate the configuration:
 
-```bash
-zabbix_server -T
-```
+!!! info "Validating the configuration"
 
-Restart the Zabbix server:
+    ```bash
+    zabbix_server -T
+    ```
 
-```bash
-systemctl restart zabbix-server
-```
+If the configuration test passes, restart the Zabbix server:
+
+!!! info "Restarting the Zabbix server"
+
+    ```bash
+    systemctl restart zabbix-server
+    ```
 
 Monitor the log:
 
-```bash
-tail -f /var/log/zabbix/zabbix_server.log
-```
+!!! info "Monitoring the Zabbix server log"
+
+    ```bash
+    tail -f /var/log/zabbix/zabbix_server.log
+    ```
 
 A successful connection produces output similar to:
 
-```bash
-retrieving history provider "clickhouse" information
-history provider "clickhouse" version "26.6.1.1193"
-```
+!!! example "Successful connection to ClickHouse"
+
+    ```bash
+    retrieving history provider "clickhouse" information
+    history provider "clickhouse" version "26.6.1.1193"
+    ```
 
 At this point, newly collected history values are being written directly
 to ClickHouse.
+
+---
 
 ## Verifying ClickHouse
 
@@ -344,60 +506,76 @@ A few simple commands confirm that ClickHouse is functioning correctly.
 
 Check the installed version:
 
-```bash
-clickhouse-client --query "SELECT version()"
-```
+!!! info "Checking the ClickHouse version"
+    ```bash
+    clickhouse-client --query "SELECT version()"
+    ```
 
 Verify that the HTTP interface is operational:
 
-```bash
-curl http://127.0.0.1:8123/ping
-```
+!!! info "Verifying the HTTP interface"
 
-Expected output:
+    ```bash
+    curl http://127.0.0.1:8123/ping
+    ```
 
-```bash
-Ok.
-```
+    Expected output:
+
+    ```bash
+    Ok.
+    ```
 
 List the imported tables:
 
-```sql
-SHOW TABLES;
-```
+!!! info "Listing the ClickHouse tables"
 
-Expected output:
+    Connect to ClickHouse using `clickhouse-client` and run:
 
-```bash
-history
-history_uint
-history_str
-history_text
-history_log
-history_json
-```
+    ```sql
+    USE zabbix;
+    SHOW TABLES;
+    ```
+
+    Expected output:
+
+    ```bash
+    history
+    history_uint
+    history_str
+    history_text
+    history_log
+    history_json
+    ```
 
 If all six tables are present and Zabbix reports a successful connection, the
 history backend is correctly configured.
+
+---
 
 ## Frontend
 
 In our frontend file `zabbix.conf.php` we also need to make some changes so that
 the frontend knows where to find the history data.
 
-`Restart PHP-FPM or Apache after modifying zabbix.conf.php if configuration caching is enabled.`
+!!! warning "Restart PHP-FPM or Apache"
 
-```
-$HISTORY_PROVIDERS[] = [
-    'types' => ['uint', 'dbl', 'str', 'log', 'text', 'json'],
-    'provider' => 'clickhouse',
-    'url' => 'http://127.0.0.1:8123',
-    'db' => 'zabbix',
-    'username' => 'zabbix',
-    'password' => 'zabbix'
-];
-```
+    Restart PHP-FPM or Apache after modifying zabbix.conf.php if configuration
+    caching is enabled.`
 
+!!! info "Zabbix frontend configuration"
+
+    Add the following to your `zabbix.conf.php` file:
+
+    ```php
+    $HISTORY_PROVIDERS[] = [
+        'types' => ['uint', 'dbl', 'str', 'log', 'text', 'json'],
+        'provider' => 'clickhouse',
+        'url' => 'http://127.0.0.1:8123',
+        'db' => 'zabbix',
+        'username' => 'zabbix',
+        'password' => 'zabbix'
+    ];
+    ```
 
 ???+ note
 
@@ -405,6 +583,7 @@ $HISTORY_PROVIDERS[] = [
     It cannot be configured as the local database or history backend of a
     Zabbix proxy.
 
+---
 
 ### Important limitations
 
@@ -415,6 +594,8 @@ $HISTORY_PROVIDERS[] = [
 - Both the Zabbix server and the frontend must be able to connect to the ClickHouse
   server.
 - Trend functions are unavailable for value types stored in ClickHouse.
+
+---
 
 ## Backups
 
@@ -436,6 +617,8 @@ requirement around historical data retention — tools like `clickhouse-backup` 
 perform consistent backups of MergeTree tables without stopping the server. Weigh
 this against your actual retention needs before adding the operational overhead.
 
+---
+
 ## Looking Ahead: Clusters and High Availability
 
 This chapter covers a single-node ClickHouse instance, which is sufficient for many
@@ -443,6 +626,8 @@ lab and small production environments. For larger or high-availability deploymen
 ClickHouse supports clustering through **ClickHouse Keeper** (for coordination),
 **ReplicatedMergeTree** tables (for data redundancy across nodes), and **distributed
 tables** (to query across shards transparently).
+
+---
 
 ## Troubleshooting
 
@@ -483,12 +668,16 @@ curl -u zabbix:zabbix \
 When Zabbix and ClickHouse run on the same server, prefer `http://127.0.0.1:8123`
 over a hostname, this avoids potential DNS or hostname resolution issues.
 
-## questions
+---
+
+## Questions
 
 - Why would you use ClickHouse instead of storing all history in PostgreSQL or MySQL?
 - Which Zabbix data is stored in ClickHouse, and which data remains in the primary database?
 - What is the purpose of the `HistoryProvider` parameter in `zabbix_server.conf`?
 - Why doesn't the Zabbix housekeeper remove data from ClickHouse?
+
+---
 
 ## Useful URLs
 


### PR DESCRIPTION
Added Suse instructions to Partitioning MySQL, TimescaleDB and ClickHouse sections.
For Vault, there are no binaries for Suse. Alternative could be from source or as a container. I left this untouched for now.